### PR TITLE
Fix Kinesis config

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :trike,
-  kinesis_client: ExAws.Kinesis
+  kinesis_client: Trike.KinesisClient
 
 config :logger, backends: [Logger.Backend.Splunk, :console]
 

--- a/test/proxy_test.exs
+++ b/test/proxy_test.exs
@@ -1,6 +1,5 @@
 defmodule ProxyTest do
   use ExUnit.Case
-  import ExUnit.CaptureLog
   alias Fakes.FakeDateTime
   alias Trike.Proxy
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fix Trike Kinesis configuration (again)](https://app.asana.com/0/584764604969369/1201002280262525/f)

Modified `prod.exs` to use `Trike.KinesisClient`, which submits requests to AWS. It was still using `ExAws.Kinesis`, causing `proxy.ex:86` to crash the application with a bad match error. Also fixed a warning about an unused import in the unit tests.

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Lcov)
- [ ] Meets ticket's acceptance criteria
