### PR TITLE
fix: staleness log prints received as an integer, not a character

### DIFF
--- a/lib/trike/proxy.ex
+++ b/lib/trike/proxy.ex
@@ -99,7 +99,7 @@ defmodule Trike.Proxy do
   end
 
   def handle_info(:staleness_check, %{received: received} = state) do
-    Logger.info(["Stale Proxy pid=", inspect(self()), ", received=", received])
+    Logger.info("Stale Proxy pid=#{inspect(self())}, received=#{received}")
 
     {:noreply, %{state | received: 0}}
   end

--- a/test/proxy_test.exs
+++ b/test/proxy_test.exs
@@ -1,5 +1,6 @@
 defmodule ProxyTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
   alias Fakes.FakeDateTime
   alias Trike.Proxy
 
@@ -52,5 +53,11 @@ defmodule ProxyTest do
     assert_received({:put_record, "test_stream", "test_key", ^event})
 
     assert buffer == rest
+  end
+
+  test "logs staleness check" do
+    staleness_check = capture_log(fn -> Proxy.handle_info(:staleness_check, %{received: 9}) end)
+
+    assert staleness_check =~ "Stale Proxy pid=#{inspect(self())}, received=9"
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trike staleness check logs received properly](https://app.asana.com/0/584764604969369/1201078839151823/f)

Staleness logging now uses an interpolated string which simplifies logging out the stale message and is ok for performance because it doesn't happen very often. Added a test to make sure it works.

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Lcov)
- [ ] Meets ticket's acceptance criteria
