### PR TITLE
revert: use UTC timestamps in production logs

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -3,9 +3,7 @@ import Config
 config :trike,
   kinesis_client: Trike.KinesisClient
 
-config :logger,
-  backends: [Logger.Backend.Splunk, :console],
-  utc_log: true
+config :logger, backends: [Logger.Backend.Splunk, :console]
 
 config :logger, Logger.Backend.Splunk,
   host: "https://http-inputs-mbta.splunkcloud.com/services/collector/event",


### PR DESCRIPTION
This reverts commit 1c0a70db9ec3a306e8cf5a35bceed9dc09ae128b.