### PR TITLE
debug: push to kinesis in a separate process for quick async test

### DIFF
--- a/lib/trike/proxy.ex
+++ b/lib/trike/proxy.ex
@@ -85,7 +85,9 @@ defmodule Trike.Proxy do
     |> Enum.each(fn event ->
       case Jason.encode(event) do
         {:ok, event_json} ->
-          {:ok, _result} = state.put_record_fn.(stream, partition_key, event_json)
+          spawn(fn ->
+            {:ok, _result} = state.put_record_fn.(stream, partition_key, event_json)
+          end)
 
         error ->
           Logger.info(["Failed to encode message: ", inspect(error)])


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:**

As an investigative measure, putting the blocking "send to Kinesis" call in a `spawn` to make it non-blocking. Just wondering if this is where the backup is.

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Lcov)
- [ ] Meets ticket's acceptance criteria
