### PR TITLE
feat: give jobs more memory

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,7 +27,7 @@ jobs:
       on-prem-cluster: hsctd-dev-managers
       splunk-index: trike-dev
       task-cpu: 0.25
-      task-memory: 256M
+      task-memory: 512M
       task-port: 8001
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -13,7 +13,7 @@ jobs:
       on-prem-cluster: hsctd-prod-managers
       splunk-index: trike-prod
       task-cpu: 0.25
-      task-memory: 256M
+      task-memory: 512M
       task-port: 8001
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
`trike-dev` crashed under a 5x message load by failing to allocate memory. With this additional memory, it can handle an 8x message load.