### PR TITLE
feat: use 2 replicas for trike-prod

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -15,6 +15,7 @@ jobs:
       task-cpu: 0.25
       task-memory: 512M
       task-port: 8081
+      task-replicas: 2
       update-order: start-first
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This ensures that there's always at least one instance running, even if one of them crashes.