### PR TITLE
feat: configurable timeout for stale sockets

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   asdf:
     name: ASDF
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3
@@ -26,7 +26,7 @@ jobs:
 
   build:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: asdf
     steps:
       - uses: actions/checkout@v3

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,6 +15,7 @@ config :trike,
   listen_port: 8001,
   kinesis_client: Fakes.FakeKinesisClient,
   clock: DateTime,
+  stale_timeout_ms: 5 * 60 * 1_000,
   health_check_interval_ms: 60 * 1_000
 
 import_config "#{config_env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -12,6 +12,7 @@ config :ex_aws,
   json_codec: Jason
 
 config :trike,
+  listen_port: 8001,
   kinesis_client: Fakes.FakeKinesisClient,
   clock: DateTime,
   health_check_interval_ms: 60 * 1_000

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -4,8 +4,13 @@ kinesis_stream = System.get_env("KINESIS_STREAM", "console")
 splunk_token = System.get_env("TRIKE_SPLUNK_TOKEN", "")
 
 config :trike,
-  listen_port: System.get_env("LISTEN_PORT", "8001") |> String.to_integer(),
   kinesis_stream: kinesis_stream
+
+if kinesis_stream == "console" do
+  # use fake client if logging to the console
+  config :trike,
+    kinesis_client: Fakes.FakeKinesisClient
+end
 
 if config_env() == :prod and splunk_token != "" do
   config :logger, backends: [Logger.Backend.Splunk, :console]
@@ -17,8 +22,10 @@ if config_env() == :prod and splunk_token != "" do
     token: splunk_token
 end
 
-if kinesis_stream == "console" do
-  # use fake client if logging to the console
-  config :trike,
-    kinesis_client: Fakes.FakeKinesisClient
+case Integer.parse(System.get_env("LISTEN_PORT", "")) do
+  {listen_port, ""} ->
+    config :trike, :listen_port, listen_port
+
+  _ ->
+    :ok
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -29,3 +29,11 @@ case Integer.parse(System.get_env("LISTEN_PORT", "")) do
   _ ->
     :ok
 end
+
+case Integer.parse(System.get_env("STALE_TIMEOUT_MS", "")) do
+  {timeout, ""} ->
+    config :trike, :stale_timeout_ms, timeout
+
+  _ ->
+    :ok
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,8 @@
 import Config
 
 config :trike,
+  # use a random port
+  listen_port: 0,
   clock: Fakes.FakeDateTime
 
 config :logger, :console, level: :warn

--- a/lib/trike/proxy.ex
+++ b/lib/trike/proxy.ex
@@ -62,7 +62,7 @@ defmodule Trike.Proxy do
   def handle_continue({:continue_init, ref, transport}, state) do
     {:ok, socket} = :ranch.handshake(ref)
     Logger.metadata(socket: inspect(socket))
-    :ok = transport.setopts(socket, active: :once, buffer: 131_072)
+    :ok = transport.setopts(socket, active: :once, buffer: 131_072, keepalive: true)
     connection_string = format_socket(socket)
 
     Logger.info("Accepted socket: conn=#{inspect(connection_string)}")

--- a/lib/trike/proxy.ex
+++ b/lib/trike/proxy.ex
@@ -37,24 +37,26 @@ defmodule Trike.Proxy do
 
   @impl :ranch_protocol
   def start_link(ref, transport, opts) do
+    opts = Keyword.take(opts, [:stream, :kinesis_client, :clock, :stale_timeout])
+
     GenServer.start_link(__MODULE__, {
       ref,
       transport,
-      opts[:stream],
-      opts[:kinesis_client],
-      opts[:clock]
+      opts
     })
   end
 
   @impl GenServer
-  def init({ref, transport, stream, kinesis_client, clock}) do
+  def init({ref, transport, opts}) do
     Process.flag(:trap_exit, true)
+
+    kinesis_client = opts[:kinesis_client]
 
     {:ok,
      %__MODULE__{
-       stream: stream,
+       stream: opts[:stream],
        put_record_fn: &kinesis_client.put_record/4,
-       clock: clock
+       clock: opts[:clock]
      }, {:continue, {:continue_init, ref, transport}}}
   end
 

--- a/lib/trike/proxy.ex
+++ b/lib/trike/proxy.ex
@@ -18,9 +18,12 @@ defmodule Trike.Proxy do
           partition_key: String.t() | nil,
           buffer: binary(),
           last_sequence_number: String.t() | nil,
+          stale_timeout_ms: non_neg_integer(),
+          stale_timeout_ref: reference() | nil,
           put_record_fn:
             (Kinesis.stream_name(), binary(), binary() -> {:ok, term()} | {:error, term()}),
-          clock: module()
+          clock: module(),
+          ranch: module()
         }
 
   @enforce_keys [:stream, :put_record_fn, :clock]
@@ -29,7 +32,10 @@ defmodule Trike.Proxy do
                 :transport,
                 :socket,
                 :partition_key,
+                :stale_timeout_ref,
+                :stale_timeout_ms,
                 buffer: "",
+                ranch: :ranch,
                 last_sequence_number: nil
               ]
 
@@ -37,7 +43,7 @@ defmodule Trike.Proxy do
 
   @impl :ranch_protocol
   def start_link(ref, transport, opts) do
-    opts = Keyword.take(opts, [:stream, :kinesis_client, :clock, :stale_timeout])
+    opts = Keyword.take(opts, [:stream, :kinesis_client, :clock, :stale_timeout_ms])
 
     GenServer.start_link(__MODULE__, {
       ref,
@@ -54,28 +60,28 @@ defmodule Trike.Proxy do
 
     {:ok,
      %__MODULE__{
+       transport: transport,
        stream: opts[:stream],
        put_record_fn: &kinesis_client.put_record/4,
+       stale_timeout_ms:
+         Keyword.get(opts, :state_timeout_ms, Application.get_env(:trike, :stale_timeout_ms)),
        clock: opts[:clock]
-     }, {:continue, {:continue_init, ref, transport}}}
+     }, {:continue, {:continue_init, ref}}}
   end
 
   @impl GenServer
-  def handle_continue({:continue_init, ref, transport}, state) do
-    {:ok, socket} = :ranch.handshake(ref)
+  def handle_continue({:continue_init, ref}, state) do
+    {:ok, socket} = state.ranch.handshake(ref)
     Logger.metadata(socket: inspect(socket))
-    :ok = transport.setopts(socket, active: :once, buffer: 131_072, keepalive: true)
+    :ok = state.transport.setopts(socket, active: :once, buffer: 131_072, keepalive: true)
     connection_string = format_socket(socket)
 
     Logger.info("Accepted socket: conn=#{inspect(connection_string)}")
 
-    {:noreply,
-     %{
-       state
-       | transport: transport,
-         socket: socket,
-         partition_key: connection_string
-     }}
+    state = %{state | socket: socket, partition_key: connection_string}
+    state = schedule_stale_timeout(state)
+
+    {:noreply, state}
   end
 
   @impl GenServer
@@ -86,6 +92,8 @@ defmodule Trike.Proxy do
         } = state
       ) do
     {:ok, buffer, sequence_number} = handle_data(state, data)
+
+    state = schedule_stale_timeout(state)
 
     state.transport.setopts(socket, active: :once)
 
@@ -99,6 +107,14 @@ defmodule Trike.Proxy do
 
   def handle_info({:tcp_closed, socket}, %{socket: socket} = state) do
     Logger.info("Socket closed conn=#{inspect(state.partition_key)}")
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:stale_timeout, socket}, %{socket: socket} = state) do
+    Logger.info(
+      "Socket stale, closing conn=#{inspect(state.partition_key)} stale_timeout_ms=#{state.stale_timeout_ms}"
+    )
+
     {:stop, :normal, state}
   end
 
@@ -183,11 +199,24 @@ defmodule Trike.Proxy do
 
   @spec format_socket(:gen_tcp.socket()) :: String.t()
   defp format_socket(sock) do
-    with {:ok, {local_ip, local_port}} <- :inet.sockname(sock),
+    with sock when is_port(sock) <- sock,
+         {:ok, {local_ip, local_port}} <- :inet.sockname(sock),
          {:ok, {peer_ip, peer_port}} <- :inet.peername(sock) do
       "{#{:inet.ntoa(local_ip)}:#{local_port} -> #{:inet.ntoa(peer_ip)}:#{peer_port}}"
     else
       unexpected -> inspect(unexpected)
     end
+  end
+
+  @spec schedule_stale_timeout(t()) :: t()
+  defp schedule_stale_timeout(%{stale_timeout_ref: nil} = state) do
+    ref = Process.send_after(self(), {:stale_timeout, state.socket}, state.stale_timeout_ms)
+    %{state | stale_timeout_ref: ref}
+  end
+
+  defp schedule_stale_timeout(state) do
+    # already scheduled, cancel and reschedule
+    Process.cancel_timer(state.stale_timeout_ref)
+    schedule_stale_timeout(%{state | stale_timeout_ref: nil})
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [investigate missing trip information](https://app.asana.com/0/584764604969369/1203656763052470/f)

Adds a 5 minute stale connection check to `Proxy` which will disconnect the socket if no messages are received for 5 minutes. With some testing on HSCTDTST, it appears that the connection table is maintained for at least this long.

#### Reviewer Checklist
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Lcov)
- [x] Meets ticket's acceptance criteria
