### PR TITLE
feat: use host port binding, limit deploy to HSCTDTST

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -31,7 +31,9 @@ jobs:
       task-cpu: 0.25
       task-memory: 512M
       task-port: 8001
-      update-order: start-first
+      update-order: stop-first
+      port-mode: host
+      placement-constraint: "node.hostname == HSCTDTST"
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -15,8 +15,9 @@ jobs:
       task-cpu: 0.25
       task-memory: 512M
       task-port: 8081
-      task-replicas: 2
-      update-order: start-first
+      update-order: stop-first
+      port-mode: host
+      placement-constraint: "node.hostname == HSCTDPRD"
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [deploy Trike-dev using host port binding, only running on HSCTDTST](https://app.asana.com/0/116562505129567/1204069064720401)

See also:
- https://github.com/mbta/workflows/pull/10
- https://github.com/mbta/on_prem_deploy/pull/9

Changes the deploy in two ways:
- only runs the dev instance on HSCTDTST (simulating HSCTDPRD)
- bind the port directly to the host, which avoids the ingress network

Things I've tried to force the port to be rebound incorrectly:
- restarting Docker on both HSCTDTST and HSREALTIME02
- restarting HSCTDTST

I'm open to other ideas for tests to run. 

Leaving this as a draft, since it's referring to my fork of the workflows for now.

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Lcov)
- [ ] Meets ticket's acceptance criteria
