### PR TITLE
fix: close sockets when they're stale instead of just killing the proxy

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.14.3-otp-25
-erlang 25.2.1
+erlang 25.3.2.1

--- a/lib/trike/proxy.ex
+++ b/lib/trike/proxy.ex
@@ -115,6 +115,8 @@ defmodule Trike.Proxy do
       "Socket stale, closing conn=#{inspect(state.partition_key)} stale_timeout_ms=#{state.stale_timeout_ms}"
     )
 
+    state.transport.close(state.socket)
+
     {:stop, :normal, state}
   end
 

--- a/test/proxy_test.exs
+++ b/test/proxy_test.exs
@@ -186,5 +186,8 @@ defmodule ProxyTest do
 
       :ok
     end
+
+    @spec close(socket :: :gen_tcp.socket()) :: :ok
+    def close(_socket), do: :ok
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🚲 close stale sockets properly](https://app.asana.com/0/584764604969369/1205139228553581/f)

Closes the socket when it's stale instead of just killing the proxy. This ensures that FIN is sent to the client (OCS).

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Lcov)
- [ ] Meets ticket's acceptance criteria
