### PR TITLE
Revert to Erlang 25.2.1 in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.14.3-otp-25
-erlang 25.3.2.1
+erlang 25.2.1


### PR DESCRIPTION
#### Summary of changes
Reverts to Erlang 25.2.1 in .tool-versions.

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Lcov)
- [ ] Meets ticket's acceptance criteria
