### PR TITLE
Revert "Revert "feat: add sourceip as a direct field on each event""

### DIFF
--- a/lib/trike/cloud_event.ex
+++ b/lib/trike/cloud_event.ex
@@ -12,26 +12,28 @@ defmodule Trike.CloudEvent do
           id: String.t(),
           partitionkey: String.t(),
           time: DateTime.t(),
-          data: OcsRawMessage.t()
+          data: OcsRawMessage.t(),
+          sourceip: String.t()
         }
 
   @derive Jason.Encoder
-  @enforce_keys [:id, :partitionkey, :time, :data]
+  @enforce_keys [:id, :partitionkey, :sourceip, :time, :data]
   defstruct @enforce_keys ++
               [
-                source: "opstech3.mbta.com/trike",
+                source: "#{:inet.gethostname() |> elem(1)}.mbta.com/trike",
                 specversion: "1.0",
                 type: "com.mbta.ocs.raw_message"
               ]
 
   @doc """
-  Creates a CloudEvent struct given a full OCS message, the current time, and a partition key.
+  Creates a CloudEvent struct given a full OCS message, the current time, a partition key, and the source IP.
   """
-  @spec from_ocs_message(binary(), DateTime.t(), String.t()) :: t()
-  def from_ocs_message(message, current_time, partition_key) do
+  @spec from_ocs_message(binary(), DateTime.t(), String.t(), String.t()) :: t()
+  def from_ocs_message(message, current_time, partition_key, source_ip) do
     %__MODULE__{
       id: :crypto.hash(:sha, [DateTime.to_iso8601(current_time), message]) |> Base.encode64(),
       partitionkey: partition_key,
+      sourceip: source_ip,
       time: current_time,
       data: %OcsRawMessage{raw: message}
     }

--- a/lib/trike/proxy.ex
+++ b/lib/trike/proxy.ex
@@ -148,9 +148,17 @@ defmodule Trike.Proxy do
     Logger.info("got_data size=#{byte_size(data)} buf_size=#{byte_size(buffer)}")
     {messages, rest} = extract(buffer <> data)
 
+    source_ip =
+      if is_port(state.socket) do
+        {:ok, {peer_ip, _peer_port}} = :inet.peername(state.socket)
+        Enum.join(Tuple.to_list(peer_ip), ".")
+      else
+        ""
+      end
+
     records =
       messages
-      |> Enum.map(&CloudEvent.from_ocs_message(&1, current_time, partition_key))
+      |> Enum.map(&CloudEvent.from_ocs_message(&1, current_time, partition_key, source_ip))
 
     result =
       if records == [] do
@@ -176,7 +184,9 @@ defmodule Trike.Proxy do
 
         Enum.each(
           records,
-          &Logger.info("ocs_event raw=#{inspect(&1.data.raw)} time=#{inspect(&1.time)}")
+          &Logger.info(
+            "ocs_event raw=#{inspect(&1.data.raw)} time=#{inspect(&1.time)} sourceip=#{inspect(&1.sourceip)}"
+          )
         )
 
         Logger.info(

--- a/test/cloud_event_test.exs
+++ b/test/cloud_event_test.exs
@@ -5,12 +5,18 @@ defmodule CloudEventTest do
   test "creates an event from an OCS message" do
     now = Fakes.FakeDateTime.utc_now()
 
-    assert CloudEvent.from_ocs_message("4994,TSCH,02:00:06,R,RLD,W", now, "1bQ0GxT4mk") ==
+    assert CloudEvent.from_ocs_message(
+             "4994,TSCH,02:00:06,R,RLD,W",
+             now,
+             "1bQ0GxT4mk",
+             "127.0.0.1"
+           ) ==
              %CloudEvent{
                data: %Trike.OcsRawMessage{raw: "4994,TSCH,02:00:06,R,RLD,W"},
                id: "myH7tTFo1tuZdSXxQ/5QFA4Xx58=",
+               sourceip: "127.0.0.1",
                partitionkey: "1bQ0GxT4mk",
-               source: "opstech3.mbta.com/trike",
+               source: "#{:inet.gethostname() |> elem(1)}.mbta.com/trike",
                specversion: "1.0",
                time: ~U[2021-08-13 12:00:00Z],
                type: "com.mbta.ocs.raw_message"

--- a/test/proxy_test.exs
+++ b/test/proxy_test.exs
@@ -62,7 +62,7 @@ defmodule ProxyTest do
     Proxy.handle_info({:tcp, state.socket, data}, state)
 
     event =
-      ~s([{"data":{"raw":"4994,TSCH,02:00:06,R,RLD,W"},"id":"myH7tTFo1tuZdSXxQ/5QFA4Xx58=","partitionkey":"test_key","source":"opstech3.mbta.com/trike","specversion":"1.0","time":"2021-08-13T12:00:00Z","type":"com.mbta.ocs.raw_message"}])
+      ~s([{"data":{"raw":"4994,TSCH,02:00:06,R,RLD,W"},"id":"myH7tTFo1tuZdSXxQ/5QFA4Xx58=","partitionkey":"test_key","source":"#{:inet.gethostname() |> elem(1)}.mbta.com/trike","sourceip":"","specversion":"1.0","time":"2021-08-13T12:00:00Z","type":"com.mbta.ocs.raw_message"}])
 
     assert_received({:put_record, "test_stream", "test_key", ^event, []})
     assert_received({:setopts, :socket, active: :once})
@@ -74,7 +74,7 @@ defmodule ProxyTest do
     Proxy.handle_info({:tcp, :socket, data}, state)
 
     event =
-      ~s([{"data":{"raw":"4994,TSCH,02:00:06,R,RLD,W"},"id":"myH7tTFo1tuZdSXxQ/5QFA4Xx58=","partitionkey":"test_key","source":"opstech3.mbta.com/trike","specversion":"1.0","time":"2021-08-13T12:00:00Z","type":"com.mbta.ocs.raw_message"},{\"data\":{\"raw\":\"4995,TSCH,03:00:06,R,RLD,W\"},\"id\":\"O7ODUPlPMM089UZL1YLYpFIZzeo=\",\"partitionkey\":\"test_key\",\"source\":\"opstech3.mbta.com/trike\",\"specversion\":\"1.0\",\"time\":\"2021-08-13T12:00:00Z\",\"type\":\"com.mbta.ocs.raw_message\"}])
+      ~s([{"data":{"raw":"4994,TSCH,02:00:06,R,RLD,W"},"id":"myH7tTFo1tuZdSXxQ/5QFA4Xx58=","partitionkey":"test_key","source":"#{:inet.gethostname() |> elem(1)}.mbta.com/trike","sourceip":"","specversion":"1.0","time":"2021-08-13T12:00:00Z","type":"com.mbta.ocs.raw_message"},{\"data\":{\"raw\":\"4995,TSCH,03:00:06,R,RLD,W\"},\"id\":\"O7ODUPlPMM089UZL1YLYpFIZzeo=\",\"partitionkey\":\"test_key\",\"source\":\"#{:inet.gethostname() |> elem(1)}.mbta.com/trike\",\"sourceip\":\"\",\"specversion\":\"1.0\",\"time\":\"2021-08-13T12:00:00Z\",\"type\":\"com.mbta.ocs.raw_message\"}])
 
     assert_received({:put_record, "test_stream", "test_key", ^event, []})
     assert_received({:setopts, :socket, active: :once})
@@ -101,7 +101,7 @@ defmodule ProxyTest do
     {:noreply, %{buffer: buffer}} = Proxy.handle_info({:tcp, :socket, data}, state)
 
     event =
-      ~s([{"data":{"raw":"4994,TSCH,02:00:06,R,RLD,W"},"id":"myH7tTFo1tuZdSXxQ/5QFA4Xx58=","partitionkey":"test_key","source":"opstech3.mbta.com/trike","specversion":"1.0","time":"2021-08-13T12:00:00Z","type":"com.mbta.ocs.raw_message"}])
+      ~s([{"data":{"raw":"4994,TSCH,02:00:06,R,RLD,W"},"id":"myH7tTFo1tuZdSXxQ/5QFA4Xx58=","partitionkey":"test_key","source":"#{:inet.gethostname() |> elem(1)}.mbta.com/trike","sourceip":"","specversion":"1.0","time":"2021-08-13T12:00:00Z","type":"com.mbta.ocs.raw_message"}])
 
     assert_received({:put_record, "test_stream", "test_key", ^event, []})
 


### PR DESCRIPTION
Bring back `sourceip` field. 

Do not merge until https://github.com/mbta/ocs_saver/pull/429 is deployed. 