### PR TITLE
fix: bump stale connection refresh interval back up to 5 minutes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,7 @@ config :trike,
   listen_port: 8001,
   kinesis_client: Fakes.FakeKinesisClient,
   clock: DateTime,
-  stale_timeout_ms: 55 * 1_000,
+  stale_timeout_ms: 5 * 60 * 1_000,
   health_check_interval_ms: 60 * 1_000
 
 import_config "#{config_env()}.exs"


### PR DESCRIPTION
fix: bump stale connection refresh interval back up to 5 minutes

Asana Ticket: [🚲 Lower kill stale connection threshold to 55 seconds](https://app.asana.com/0/584764604969369/1206530105587862/f)

Reverts mbta/trike#38