### PR TITLE
various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Trike is a simple application in the spirit of [socket_proxy](https://github.com
 Trike comes with a small tool, `fake_source`, for feeding it data over TCP for testing purposes. To use the tool:
 - Ensure the application is running: `mix run --no-halt`
 - Open a new terminal in the repository root
-- Run the tool: `mix fake_source [--trike-port port_number] [--good] [--bad]`
+- Run the tool: `mix fake_source [--port port_number] [--good] [--bad]`
   - By default, the tool assumes Trike is running on port 8001
   - The `--good` option will send Trike canned OCS messages from `priv/ocs_data.csv`
   - The `--bad` option will send Trike random bytes of data

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,6 +17,7 @@ config :trike,
   kinesis_client: Fakes.FakeKinesisClient,
   clock: DateTime,
   stale_timeout_ms: 5 * 60 * 1_000,
-  health_check_interval_ms: 60 * 1_000
+  health_check_interval_ms: 60 * 1_000,
+  heartbeat_packet: "HEARTBEAT"
 
 import_config "#{config_env()}.exs"

--- a/lib/mix/tasks/fake_source.ex
+++ b/lib/mix/tasks/fake_source.ex
@@ -16,10 +16,10 @@ defmodule Mix.Tasks.FakeSource do
   def run(args) do
     {opts, _, _} =
       OptionParser.parse(args,
-        strict: [{:"trike-port", :integer}, host: :string, bad: :boolean, good: :boolean]
+        strict: [{:port, :integer}, host: :string, bad: :boolean, good: :boolean]
       )
 
-    port = opts[:"trike-port"] || 8001
+    port = opts[:port] || 8001
     bad = opts[:bad]
     good = opts[:good]
     host = String.to_charlist(opts[:host] || "localhost")
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.FakeSource do
         {:ok, sock}
 
       {:error, err} ->
-        Logger.info("Couldn't connect: #{err}, trying again shortly")
+        Logger.info("Couldn't connect to #{host}:#{port}: #{err}, trying again shortly")
         :timer.sleep(2_000)
         do_connect(host, port)
     end

--- a/lib/mix/tasks/fake_source.ex
+++ b/lib/mix/tasks/fake_source.ex
@@ -2,11 +2,12 @@ defmodule Mix.Tasks.FakeSource do
   @moduledoc """
   A fake source of OCS messages that reads in canned messages from
   priv/ocs_data.csv and sends them to Trike on the specified port (8001 by
-  default). Also sends bad data if you ask it to.
+  default). Also sends bad data and heartbeats if you ask it to.
   """
   use Mix.Task
   require Logger
 
+  @heartbeat Application.compile_env(:trike, :heartbeat_packet)
   @eot <<4>>
 
   @doc """
@@ -16,15 +17,22 @@ defmodule Mix.Tasks.FakeSource do
   def run(args) do
     {opts, _, _} =
       OptionParser.parse(args,
-        strict: [{:port, :integer}, host: :string, bad: :boolean, good: :boolean]
+        strict: [
+          {:port, :integer},
+          host: :string,
+          bad: :boolean,
+          good: :boolean,
+          heartbeat: :boolean
+        ]
       )
 
     port = opts[:port] || 8001
     bad = opts[:bad]
     good = opts[:good]
+    heartbeat = opts[:heartbeat]
     host = String.to_charlist(opts[:host] || "localhost")
     {:ok, sock} = do_connect(host, port)
-    do_send(sock, host, port, good, bad)
+    do_send(sock, host, port, good, bad, heartbeat)
   end
 
   @spec do_connect(:inet.hostname(), :inet.port_number()) :: {:ok, :gen_tcp.socket()}
@@ -45,19 +53,25 @@ defmodule Mix.Tasks.FakeSource do
           :inet.hostname(),
           :inet.port_number(),
           boolean(),
+          boolean(),
           boolean()
         ) ::
           no_return()
-  defp do_send(sock, host, port, send_good, send_bad) do
+  defp do_send(sock, host, port, send_good, send_bad, heartbeat) do
     "priv/ocs_data.csv"
     |> File.stream!()
     |> Stream.map(&String.trim/1)
-    |> Stream.take_while(fn line ->
+    |> Stream.with_index()
+    |> Stream.take_while(fn {line, index} ->
       :timer.sleep(1_000)
       fail = rem(Time.utc_now().second, 5) == 0
       bytes = :crypto.strong_rand_bytes(5)
 
       cond do
+        heartbeat && rem(index, 30) == 0 ->
+          Logger.info("Sending heartbeat")
+          log_if_not_ok(:gen_tcp.send(sock, [@heartbeat, @eot]))
+
         send_good && send_bad && fail ->
           Logger.info("Sending bad message #{inspect(bytes)}")
           log_if_not_ok(:gen_tcp.send(sock, [bytes, @eot]))
@@ -69,13 +83,17 @@ defmodule Mix.Tasks.FakeSource do
         send_bad ->
           Logger.info("Sending bad message #{inspect(bytes)}")
           log_if_not_ok(:gen_tcp.send(sock, [bytes, @eot]))
+
+        heartbeat ->
+          # don't send a packet if it's not the heartbeat time
+          true
       end
     end)
     |> Stream.run()
 
     :gen_tcp.close(sock)
     {:ok, sock} = do_connect(host, port)
-    do_send(sock, host, port, send_good, send_bad)
+    do_send(sock, host, port, send_good, send_bad, heartbeat)
   end
 
   defp log_if_not_ok(:ok) do

--- a/test/proxy_test.exs
+++ b/test/proxy_test.exs
@@ -133,6 +133,17 @@ defmodule ProxyTest do
     refute new_state.stale_timeout_ref == state.stale_timeout_ref
   end
 
+  test "does not send a heartbeat message to Kinesis", %{state: state} do
+    heartbeat = Application.get_env(:trike, :heartbeat_packet)
+    data = "#{heartbeat}#{@eot}"
+
+    {:noreply, new_state} = Proxy.handle_info({:tcp, state.socket, data}, state)
+
+    refute_received({:put_record, "test_stream", "test_key", _, _})
+    assert_received({:setopts, :socket, active: :once})
+    refute new_state.stale_timeout_ref == state.stale_timeout_ref
+  end
+
   test "logs connection string on shutdown", %{state: state} do
     connection_string = "1.2.3.4:5 -> 6.7.8.9:10"
 

--- a/test/proxy_test.exs
+++ b/test/proxy_test.exs
@@ -42,7 +42,9 @@ defmodule ProxyTest do
       ref = make_ref()
       {:noreply, state} = Proxy.handle_continue({:continue_init, ref}, state)
       socket = state.socket
-      assert_receive {:setopts, ^socket, [active: :once, buffer: _, keepalive: true]}
+
+      assert_receive {:setopts, ^socket,
+                      [active: :once, buffer: _, keepalive: true, linger: {true, 0}]}
     end
 
     test "starts a timer for stale messages", %{state: state} do


### PR DESCRIPTION
- use `linger` of `{true, 0}` to send TCP RST immediately on timeout
- ignore a `HEARTBEAT` packet but reset the timeout

## Validations
timeout: `socat TCP:HSCTDLNXSTG01:49152,ignoreeof STDIO` + Wireshark
<img width="1272" alt="Screenshot 2024-02-15 at 11 45 54 AM" src="https://github.com/mbta/trike/assets/214921/3d2d6f0f-2fba-477f-a764-f6b900b9aec1">

heartbeat: `mix fake_source --host HSCTDLNXSTG01 --port <port> -heartbeat` + Splunk

The packet with size=10 is the heartbeat, and we see that does not trigger an `ocs_event` or `put_record_timing` message.
<img width="1107" alt="Screenshot 2024-02-15 at 11 48 29 AM" src="https://github.com/mbta/trike/assets/214921/2c83e16c-b4eb-43b1-a3d1-1b7adbfb84f6">

#### Reviewer Checklist
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Lcov)
- [x] Meets ticket's acceptance criteria
