### PR TITLE
chore: Bump Ubuntu version used by elixir.yml

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   asdf:
     name: ASDF
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
 
   build:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: asdf
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
#### Summary of changes
**Asana ticket**: [🚲 Ubuntu 20.04 runners being discontinued](https://app.asana.com/1/15492006741476/project/584764604969369/task/1209410795125944?focus=true)

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Lcov)
- [ ] Meets ticket's acceptance criteria
